### PR TITLE
Fixed keycloak_admin_pwd variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Role Variables
 |`multi_user_che_protocol`    | `http`             | Optional | For multi-user mode, `http` or `https` protocol |
 |`multi_user_che_ws_protocol` | `ws`               | Optional | For multi-user mode, `ws` or `wss` protocol |
 |`keycloak_admin_user`        | `admin`            | Optional | For multi-user mode, Keycloak admin user to be created |
-|`keycloak_admin_user`        | `admin`            | Optional | For multi-user mode, Keycloak admin password to be created |
+|`keycloak_admin_pwd`         | `admin`            | Optional | For multi-user mode, Keycloak admin password to be created |
 |`install_java_oc_stack`      | `false`            | Optional | Install a Java stack with Maven, OpenShift CLI and Ansible |
 |`openshift_cli`              | `oc`               | Optional | OpenShift CLI command and arguments (e.g. auth) | 
 


### PR DESCRIPTION
In the Readme the variable `keycloak_admin_pwd` is currently identified as `keycloak_admin_user`